### PR TITLE
added python-decouple into requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 numpy
 rdflib
 SPARQLWrapper
+python-decouple


### PR DESCRIPTION
(the need observer during failed migration in PROFIT platform which was calling pp_api/pp_calls.py and pp_api/utils.py)